### PR TITLE
Fix architecture detection to recognize x86_64 in kiota-maven-plugin

### DIFF
--- a/maven/plugin/src/main/java/io/kiota/maven/plugin/KiotaMojo.java
+++ b/maven/plugin/src/main/java/io/kiota/maven/plugin/KiotaMojo.java
@@ -446,7 +446,7 @@ public class KiotaMojo extends AbstractMojo {
             if ("aarch64".equals(rawArchString)) {
                 return ARM64;
             }
-            if (rawArchString.matches("^(x8664|amd64|ia32e|em64t|x64)$")) {
+            if (rawArchString.matches("^(x8664|x86_64|amd64|ia32e|em64t|x64)$")) {
                 return X64;
             }
             if (rawArchString.matches("^(x8632|x86|i[3-6]86|ia32|x32)$")) {


### PR DESCRIPTION
Fixes #243

This PR updates the architecture detection regex in KiotaMojo.java to recognize x86_64 as a valid x64 architecture, in addition to amd64 and others.

**Background:**
Some systems report the architecture as x86_64, which wasn't recognized by the previous regex. This prevented the Maven plugin from working on affected systems.

**Change:**

Added x86_64 to the architecture regex.

**Not Tested**
I can't test it as i use it as  plugin in another build. 


