### PR TITLE
Add kiota.downloadURL property for direct zip URL support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .claude
 .idea
 .project
+.serena
 .vscode
 target

--- a/maven/plugin/src/main/java/io/kiota/maven/plugin/KiotaMojo.java
+++ b/maven/plugin/src/main/java/io/kiota/maven/plugin/KiotaMojo.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
+import java.net.URI;
 import java.net.URL;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
@@ -15,6 +16,7 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -34,6 +36,9 @@ import org.apache.maven.project.MavenProject;
 @Mojo(name = "generate", defaultPhase = LifecyclePhase.GENERATE_SOURCES)
 public class KiotaMojo extends AbstractMojo {
     private final Log log = new SystemStreamLog();
+
+    private static final String DEFAULT_BASE_URL =
+            "https://github.com/microsoft/kiota/releases/download";
 
     /**
      * Skip the execution of the goal
@@ -66,12 +71,22 @@ public class KiotaMojo extends AbstractMojo {
     private String osArch;
 
     /**
-     * Base URL to be used for the download
+     * Base URL to be used for the download. Must be HTTP or HTTPS.
+     * The plugin appends {@code /v{version}/{artifact}.zip} to this URL.
+     * Mutually exclusive with {@link #downloadURL}.
      */
-    @Parameter(
-            defaultValue = "https://github.com/microsoft/kiota/releases/download",
-            property = "kiota.baseURL")
+    @Parameter(defaultValue = DEFAULT_BASE_URL, property = "kiota.baseURL")
     private String baseURL;
+
+    /**
+     * Full URL to a Kiota distribution zip archive. Supports HTTP, HTTPS, and file:// protocols.
+     * The zip must contain the platform-specific Kiota binary ({@code kiota} or {@code kiota.exe})
+     * at the archive root, matching the layout of the official Kiota release artifacts
+     * (e.g. {@code linux-x64.zip}).
+     * When set, {@link #baseURL} must remain at its default value.
+     */
+    @Parameter(property = "kiota.downloadURL")
+    String downloadURL;
 
     /**
      * Version of Kiota to be used
@@ -296,10 +311,29 @@ public class KiotaMojo extends AbstractMojo {
                     Path.of(targetBinaryFolder.getAbsolutePath(), kiotaVersion)
                             .toFile()
                             .getAbsolutePath();
-            downloadAndExtract(
-                    baseURL + "/v" + kiotaVersion + "/" + kp.downloadArtifact() + ".zip",
-                    executablePath,
-                    kp);
+
+            if (downloadURL != null && !downloadURL.isEmpty()) {
+                if (!DEFAULT_BASE_URL.equals(baseURL)) {
+                    throw new IllegalArgumentException(
+                            "kiota.downloadURL and kiota.baseURL are mutually exclusive."
+                                    + " Please configure only one of them.");
+                }
+                warnIfInsecureHttp(downloadURL, "kiota.downloadURL");
+                downloadAndExtract(downloadURL, executablePath, kp);
+            } else {
+                if (!baseURL.startsWith("http://") && !baseURL.startsWith("https://")) {
+                    throw new IllegalArgumentException(
+                            "kiota.baseURL must use HTTP or HTTPS protocol. Got: "
+                                    + baseURL
+                                    + ". To use a file:// or full URL, set kiota.downloadURL"
+                                    + " instead.");
+                }
+                warnIfInsecureHttp(baseURL, "kiota.baseURL");
+                downloadAndExtract(
+                        baseURL + "/v" + kiotaVersion + "/" + kp.downloadArtifact() + ".zip",
+                        executablePath,
+                        kp);
+            }
             executable = Paths.get(executablePath, kp.binary()).toFile().getAbsolutePath();
         }
 
@@ -508,7 +542,6 @@ public class KiotaMojo extends AbstractMojo {
                 return;
             } catch (IOException e) {
                 lastException = e;
-                // Clean up partial downloads
                 zipFile.delete();
                 finalDestination.delete();
 
@@ -539,6 +572,15 @@ public class KiotaMojo extends AbstractMojo {
                 lastException);
     }
 
+    private void warnIfInsecureHttp(String url, String property) {
+        if (url.startsWith("http://")) {
+            log.warn(
+                    property
+                            + " uses plain HTTP, which is vulnerable to interception."
+                            + " Consider using HTTPS instead.");
+        }
+    }
+
     private String resolveDownloadToken() {
         if (downloadToken != null && !downloadToken.isEmpty()) {
             return downloadToken;
@@ -556,6 +598,11 @@ public class KiotaMojo extends AbstractMojo {
     }
 
     void downloadFile(String url, File destination) throws IOException {
+        URI uri = URI.create(url);
+        if ("file".equals(uri.getScheme())) {
+            Files.copy(Path.of(uri), destination.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            return;
+        }
         URL s = new URL(url);
         HttpURLConnection connection = (HttpURLConnection) s.openConnection();
         connection.setInstanceFollowRedirects(true);

--- a/maven/plugin/src/test/java/io/kiota/maven/plugin/KiotaMojoDownloadTest.java
+++ b/maven/plugin/src/test/java/io/kiota/maven/plugin/KiotaMojoDownloadTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -91,6 +92,60 @@ class KiotaMojoDownloadTest {
         mojo.downloadFile(server.url("/test.zip").toString(), dest);
 
         assertNull(server.takeRequest().getHeader("Authorization"));
+    }
+
+    @Test
+    void downloadFile_fileUrl_copiesFile() throws Exception {
+        Path source = tempDir.resolve("source.zip");
+        byte[] content = "zip-content".getBytes();
+        Files.write(source, content);
+
+        File dest = tempDir.resolve("downloaded.zip").toFile();
+        mojo.downloadFile(source.toUri().toString(), dest);
+
+        assertArrayEquals(content, Files.readAllBytes(dest.toPath()));
+    }
+
+    @Test
+    void downloadAndExtract_fileUrlZip() throws Exception {
+        byte[] zipBytes = createKiotaZip("kiota");
+        Path zipFile = tempDir.resolve("kiota.zip");
+        Files.write(zipFile, zipBytes);
+        String dest = tempDir.resolve("extract").toString();
+        mojo.downloadAndExtract(
+                zipFile.toUri().toString(), dest, new KiotaMojo.KiotaParams("Linux", "amd64"));
+        assertTrue(new File(dest, "kiota").exists());
+    }
+
+    @Test
+    void downloadAndExtract_httpUrlViaDownloadUrl() throws Exception {
+        byte[] zipBytes = createKiotaZip("kiota");
+        server.enqueue(new MockResponse().setBody(new Buffer().write(zipBytes)));
+
+        mojo.downloadURL = server.url("/custom/kiota-v1.zip").toString();
+
+        String dest = tempDir.resolve("extract").toString();
+        mojo.downloadAndExtract(
+                mojo.downloadURL, dest, new KiotaMojo.KiotaParams("Linux", "amd64"));
+
+        assertTrue(new File(dest, "kiota").exists());
+        assertEquals(1, server.getRequestCount());
+    }
+
+    @Test
+    void downloadAndExtract_nonZipFile_fails() {
+        byte[] binaryContent = "#!/bin/sh\necho kiota".getBytes();
+        Path binarySource = tempDir.resolve("not-a-zip");
+        assertDoesNotThrow(() -> Files.write(binarySource, binaryContent));
+
+        String dest = tempDir.resolve("extract").toString();
+        assertThrows(
+                IllegalStateException.class,
+                () ->
+                        mojo.downloadAndExtract(
+                                binarySource.toUri().toString(),
+                                dest,
+                                new KiotaMojo.KiotaParams("Linux", "amd64")));
     }
 
     private byte[] createKiotaZip(String binaryName) throws IOException {


### PR DESCRIPTION
## Motivation

In certain CI/CD environments, the Kiota binary zip is pre-downloaded and available on the local filesystem. Pointing `kiota.baseURL` at a `file://` path caused a `ClassCastException` because `downloadFile()` unconditionally cast the connection to `HttpURLConnection`, which fails for `FileURLConnection`. Additionally, `baseURL` always appends `/v{version}/{artifact}.zip`, making it impossible to reference a specific zip at an arbitrary location.

## Summary

- Add a new `kiota.downloadURL` Maven property that accepts a full URL (HTTP, HTTPS, or `file://`) to a Kiota distribution zip archive, allowing users to point at a pre-downloaded or internally-hosted zip without the plugin appending version/artifact path segments
- Support `file://` protocol in download methods via `Files.copy`, fixing the `ClassCastException`
- Validate that `kiota.baseURL` uses HTTP/HTTPS protocol, enforce mutual exclusivity with `kiota.downloadURL`, and warn when plain HTTP is used

## Test plan

- [x] Existing download/retry tests still pass
- [x] `downloadFile` with `file://` URL copies file correctly
- [x] `downloadAndExtract` with `file://` URL to a zip extracts binary
- [x] `downloadAndExtract` with HTTP URL via `downloadURL` downloads and extracts
- [x] `downloadAndExtract` with non-zip file fails with `IllegalStateException`
- [ ] Manual: use `-Dkiota.downloadURL=file:///path/to/linux-x64.zip` with a pre-downloaded Kiota release zip