### PR TITLE
feat: support file:// and direct zip URLs in baseURL transparently

### DIFF
--- a/maven/plugin/src/main/java/io/kiota/maven/plugin/KiotaMojo.java
+++ b/maven/plugin/src/main/java/io/kiota/maven/plugin/KiotaMojo.java
@@ -304,13 +304,7 @@ public class KiotaMojo extends AbstractMojo {
                     || baseURL.toLowerCase(Locale.ROOT).endsWith(".zip")) {
                 downloadUrl = baseURL;
             } else {
-                downloadUrl =
-                        baseURL
-                                + "/v"
-                                + kiotaVersion
-                                + "/"
-                                + kp.downloadArtifact()
-                                + ".zip";
+                downloadUrl = baseURL + "/v" + kiotaVersion + "/" + kp.downloadArtifact() + ".zip";
             }
             downloadAndExtract(downloadUrl, executablePath, kp);
             executable = Paths.get(executablePath, kp.binary()).toFile().getAbsolutePath();

--- a/maven/plugin/src/main/java/io/kiota/maven/plugin/KiotaMojo.java
+++ b/maven/plugin/src/main/java/io/kiota/maven/plugin/KiotaMojo.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
+import java.net.URI;
 import java.net.URL;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
@@ -15,6 +16,7 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -296,10 +298,21 @@ public class KiotaMojo extends AbstractMojo {
                     Path.of(targetBinaryFolder.getAbsolutePath(), kiotaVersion)
                             .toFile()
                             .getAbsolutePath();
-            downloadAndExtract(
-                    baseURL + "/v" + kiotaVersion + "/" + kp.downloadArtifact() + ".zip",
-                    executablePath,
-                    kp);
+            String downloadUrl;
+            URI baseUri = URI.create(baseURL);
+            if ("file".equals(baseUri.getScheme())
+                    || baseURL.toLowerCase(Locale.ROOT).endsWith(".zip")) {
+                downloadUrl = baseURL;
+            } else {
+                downloadUrl =
+                        baseURL
+                                + "/v"
+                                + kiotaVersion
+                                + "/"
+                                + kp.downloadArtifact()
+                                + ".zip";
+            }
+            downloadAndExtract(downloadUrl, executablePath, kp);
             executable = Paths.get(executablePath, kp.binary()).toFile().getAbsolutePath();
         }
 
@@ -556,6 +569,11 @@ public class KiotaMojo extends AbstractMojo {
     }
 
     void downloadFile(String url, File destination) throws IOException {
+        URI uri = URI.create(url);
+        if ("file".equals(uri.getScheme())) {
+            Files.copy(Path.of(uri), destination.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            return;
+        }
         URL s = new URL(url);
         HttpURLConnection connection = (HttpURLConnection) s.openConnection();
         connection.setInstanceFollowRedirects(true);

--- a/maven/plugin/src/test/java/io/kiota/maven/plugin/KiotaMojoDownloadTest.java
+++ b/maven/plugin/src/test/java/io/kiota/maven/plugin/KiotaMojoDownloadTest.java
@@ -4,7 +4,9 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -91,6 +93,48 @@ class KiotaMojoDownloadTest {
         mojo.downloadFile(server.url("/test.zip").toString(), dest);
 
         assertNull(server.takeRequest().getHeader("Authorization"));
+    }
+
+    @Test
+    void downloadFile_fileUrl_copiesFile() throws Exception {
+        File source = tempDir.resolve("source.zip").toFile();
+        Files.writeString(source.toPath(), "zip-content");
+
+        File dest = tempDir.resolve("dest.zip").toFile();
+        mojo.downloadFile(source.toURI().toString(), dest);
+
+        assertEquals("zip-content", Files.readString(dest.toPath()));
+    }
+
+    @Test
+    void downloadAndExtract_fileUrlZip() throws Exception {
+        byte[] zipBytes = createKiotaZip("kiota");
+        File zipFile = tempDir.resolve("kiota-local.zip").toFile();
+        try (FileOutputStream fos = new FileOutputStream(zipFile)) {
+            fos.write(zipBytes);
+        }
+
+        String dest = tempDir.resolve("extract-file").toString();
+        mojo.downloadAndExtract(
+                zipFile.toURI().toString(),
+                dest,
+                new KiotaMojo.KiotaParams("Linux", "amd64"));
+
+        assertTrue(new File(dest, "kiota").exists());
+    }
+
+    @Test
+    void downloadAndExtract_directHttpZipUrl() throws Exception {
+        byte[] zipBytes = createKiotaZip("kiota");
+        server.enqueue(new MockResponse().setBody(new Buffer().write(zipBytes)));
+
+        String dest = tempDir.resolve("extract-direct").toString();
+        mojo.downloadAndExtract(
+                server.url("/custom-path/kiota-linux-x64.zip").toString(),
+                dest,
+                new KiotaMojo.KiotaParams("Linux", "amd64"));
+
+        assertTrue(new File(dest, "kiota").exists());
     }
 
     private byte[] createKiotaZip(String binaryName) throws IOException {

--- a/maven/plugin/src/test/java/io/kiota/maven/plugin/KiotaMojoDownloadTest.java
+++ b/maven/plugin/src/test/java/io/kiota/maven/plugin/KiotaMojoDownloadTest.java
@@ -116,9 +116,7 @@ class KiotaMojoDownloadTest {
 
         String dest = tempDir.resolve("extract-file").toString();
         mojo.downloadAndExtract(
-                zipFile.toURI().toString(),
-                dest,
-                new KiotaMojo.KiotaParams("Linux", "amd64"));
+                zipFile.toURI().toString(), dest, new KiotaMojo.KiotaParams("Linux", "amd64"));
 
         assertTrue(new File(dest, "kiota").exists());
     }


### PR DESCRIPTION
Alternative to #338 

Detect the user's intent from the baseURL value itself: if it uses the file:// scheme or ends with .zip, use it as a direct download URL; otherwise append the version/artifact path as before. This avoids introducing a second mutually exclusive property while supporting pre-downloaded zips and custom mirrors.