### PR TITLE
Bump Vert.x to 5.1.3

### DIFF
--- a/libraries/http-vertx/pom.xml
+++ b/libraries/http-vertx/pom.xml
@@ -23,18 +23,22 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-core</artifactId>
+      <version>${vertx.version}</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-web-client</artifactId>
+      <version>${vertx.version}</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-auth-common</artifactId>
+      <version>${vertx.version}</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-auth-oauth2</artifactId>
+      <version>${vertx.version}</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <quarkus.version>3.36.2</quarkus.version>
     <kiota.libs.version>1.9.3</kiota.libs.version>
+    <vertx.version>5.1.3</vertx.version>
     <spotless.version>3.6.0</spotless.version>
   </properties>
   <dependencyManagement>


### PR DESCRIPTION
## Summary
- Pins Vert.x version to 5.1.3 (overriding the Quarkus BOM-managed version) to prepare for the Vert.x 5 migration
- No source code changes required — the http-vertx module compiles cleanly against Vert.x 5

Related: https://github.com/quarkusio/quarkus/issues/51959

## Test plan
- [ ] Verify CI passes (compile + tests)
- [ ] Verify no runtime regressions with Vert.x 5 WebClient